### PR TITLE
performed unit testing on admin-sports component

### DIFF
--- a/CourtLink/src/app/components/admin-sports/admin-sports.component.spec.ts
+++ b/CourtLink/src/app/components/admin-sports/admin-sports.component.spec.ts
@@ -1,23 +1,60 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AdminSportsComponent } from './admin-sports.component';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { AddSportDialogComponent } from '../add-sport-dialog/add-sport-dialog.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('AdminSportsComponent', () => {
   let component: AdminSportsComponent;
   let fixture: ComponentFixture<AdminSportsComponent>;
+  let httpMock: HttpTestingController;
+  let dialogSpy: jasmine.Spy;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AdminSportsComponent]
-    })
-    .compileComponents();
+      imports: [
+        HttpClientTestingModule,
+        MatDialogModule,
+        BrowserAnimationsModule,
+        AdminSportsComponent,
+        AddSportDialogComponent
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AdminSportsComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should fetch and display sports', fakeAsync(() => {
+    const mockSports = ['Basketball', 'Tennis'];
+    const req = httpMock.expectOne('http://localhost:8080/ListSports');
+    req.flush(mockSports);
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component.sports.length).toBe(2);
+    expect(component.sports[0].name).toBe('Basketball');
+  }));
+
+  it('should not add sport if dialog is cancelled', () => {
+    const dialog = TestBed.inject(MatDialog);
+    component.sports = [];
+
+    spyOn(dialog, 'open').and.returnValue({
+      afterClosed: () => of(null)
+    } as any);
+
+    component.openAddSportDialog();
+
+    expect(component.sports.length).toBe(0);
   });
 });


### PR DESCRIPTION
I have done some unit testing on the admin-sports component, I have attached an image for reference. the test cases are as follows:

1. should create the component- Verifies that the AdminSportsComponent initializes correctly without errors.
2. should fetch and display sports- Mocks a backend response with an array of sports (['Basketball', 'Tennis']) and ensures the component stores them correctly in sports[] and can access their names.
3. should not add sport if dialog is cancelled- Mocks the user closing the "Add Sport" dialog without submitting. Also verifies that no sport is added to the sports[] list.

<img width="1512" alt="Screenshot 2025-03-31 at 1 30 12 PM" src="https://github.com/user-attachments/assets/53031af7-ac5b-476c-97d1-0ce7d7193816" />
