### PR TITLE
performed unit testing on admin-courts component

### DIFF
--- a/CourtLink/src/app/components/admin-courts/admin-courts.component.spec.ts
+++ b/CourtLink/src/app/components/admin-courts/admin-courts.component.spec.ts
@@ -1,23 +1,78 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AdminCourtsComponent } from './admin-courts.component';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('AdminCourtsComponent', () => {
   let component: AdminCourtsComponent;
   let fixture: ComponentFixture<AdminCourtsComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AdminCourtsComponent]
-    })
-    .compileComponents();
+      imports: [
+        HttpClientTestingModule,
+        MatTableModule,
+        MatButtonModule,
+        MatFormFieldModule,
+        MatInputModule,
+        BrowserAnimationsModule,
+        AdminCourtsComponent,
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AdminCourtsComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should fetch and display courts', fakeAsync(() => {
+    const mockCourts = [
+      { court_name: 'Court A', sport_name: 'Tennis' },
+      { court_name: 'Court B', sport_name: 'Basketball' },
+    ];
+    const req = httpMock.expectOne('http://localhost:8080/ListCourts');
+    req.flush(mockCourts);
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component.courts.data.length).toBe(2);
+    expect(component.courts.data[0].court_name).toBe('Court A');
+  }));
+
+  it('should filter courts when search is applied', () => {
+    component.courts.data = [
+      { court_name: 'Court A', sport_name: 'Tennis' },
+      { court_name: 'Court B', sport_name: 'Basketball' },
+    ];
+
+    const inputEvent = new Event('input');
+    const inputElement = { target: { value: 'tennis' } } as unknown as Event;
+    component.applyFilter(inputElement);
+    expect(component.courts.filter).toBe('tennis');
+  });
+
+  it('should render the correct number of displayed columns', () => {
+    expect(component.displayedColumns).toEqual(['sno', 'court', 'sport', 'action']);
+  });
+
+  it('should handle empty court list without crashing', fakeAsync(() => {
+    const req = httpMock.expectOne('http://localhost:8080/ListCourts');
+    req.flush([]);
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component.courts.data.length).toBe(0);
+  }));
 });


### PR DESCRIPTION
I have completed testing of the admin-courts component and have attached an image for reference. The tests performed are as follows:

1. should create the component- Verifies the component initializes without crashing.
2. should fetch and display courts- Mocks a backend API response with a list of courts and simulates the HTTP GET request to /ListCourts. It also Ensures the courts are correctly assigned to the dataSource.
3. should filter courts when search is applied- Sets mock court data manually into the table before simulating a search input event with the keyword 'tennis'. It then verifies the component’s filter value updates correctly.
4. should render the correct number of displayed columns- Checks that the displayed columns in the table match: ['sno', 'court', 'sport', 'action'].
5. should handle empty court list without crashing- Mocks an empty array as the backend response and ensures the component handles the empty data well. Confirms that the table’s data is indeed empty.

<img width="1512" alt="Screenshot 2025-03-31 at 1 46 25 PM" src="https://github.com/user-attachments/assets/c2c11224-e0a0-4350-a916-50658a8557ba" />
